### PR TITLE
Deleting an author #6

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -5,4 +5,12 @@ class AuthorsController < ApplicationController
     @books = @author.books
     @best_review = @author.best_review
   end
+
+  def destroy
+    @books = AuthorBook.where(author_id: params[:id]).pluck(:book_id)
+    Book.destroy(@books)
+    AuthorBook.where(book_id: @books).destroy_all
+
+    redirect_to books_path
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -27,6 +27,11 @@ class BooksController < ApplicationController
     redirect_to book_path(@book.id)
   end
 
+  def destroy
+    Book.destroy(params[:id])
+    redirect_to books_path
+  end
+
   private
 
   def book_params

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,6 +15,11 @@ class ReviewsController < ApplicationController
     redirect_to book_path(params[:book_id])
   end
 
+  def destroy
+    Review.destroy(params[:id])
+    redirect_to user_path(params[:user])
+  end
+
   private
 
   def review_params

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,7 +1,7 @@
 class Author < ApplicationRecord
 
-  has_many :author_books
-  has_many :books, through: :author_books
+  has_many :author_books, dependent: :destroy
+  has_many :books, through: :author_books, dependent: :destroy
 
   validates_presence_of :name
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,7 +1,7 @@
 class Book < ApplicationRecord
   has_many :reviews
-  has_many :author_books
-  has_many :authors, through: :author_books
+  has_many :author_books, dependent: :destroy
+  has_many :authors, through: :author_books, dependent: :destroy
 
   validates_presence_of :title
   validates_presence_of :pages

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -15,7 +15,6 @@ class Review < ApplicationRecord
   end
 
   def delete_review(id)
-    binding.pry
     Review.destroy(id)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -15,6 +15,7 @@ class Review < ApplicationRecord
   end
 
   def delete_review(id)
+    binding.pry
     Review.destroy(id)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -13,4 +13,8 @@ class Review < ApplicationRecord
       all
     end
   end
+
+  def delete_review(id)
+    Review.destroy(id)
+  end
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -2,7 +2,7 @@
   <div class="book-image">
     <img src="<%= @book.thumbnail %>" alt="book-<%= @book.id %>">
   </div>
-  <div class="book-info">
+  <div class="book-info" id="primary-info">
     <h1 id="book-title"><%= @book.title %></h1>
     <% @book.authors.each do |author| %>
     <p>Author(s): </p><%= link_to author.name, author_path(author.id), class: 'navlink', id:'book-author' %>
@@ -10,6 +10,7 @@
     <p>Page Count: <%= @book.pages %> </p>
     <p>Publication Date: <%= @book.year_published %></p>
     <%= link_to 'New Review', new_book_review_path(@book.id), class: 'navlink'%>
+    <%= button_to "Delete Book", book_path(@book), method: :delete %>
   </div>
 </section>
 <% @book.reviews.each do |review| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,12 +8,13 @@
   <div class="book-image" id="author-book-img">
     <img src="<%= review.book.thumbnail %>" alt="<%= review.book.title %>-cover">
   </div>
-  <div class="book-info">
+  <div class="book-info" id="book-<%= review.book.id%>">
     <p id='review-title'><%= review.title %></p>
     <p><%= review.rating %> out of 5</p>
     <p><%= review.description %></p>
     <%= link_to "#{review.book.title}: ", book_path(review.book.id), class: 'navlink' %>
     <p>Created: <%= review.created_at %></p>
+    <%= button_to "Delete Review", review_path(review), method: :delete, params: {user: @user.id} %>
   </div>
 </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
     resources :reviews, shallow: true
   end
   resources :books
-  resources :authors, only: [:show]
+  resources :authors, only: [:show, :destroy]
   resources :users, only: [:show]
 end

--- a/spec/features/author/user_sees_author_show_page_spec.rb
+++ b/spec/features/author/user_sees_author_show_page_spec.rb
@@ -69,4 +69,26 @@ RSpec.describe 'as visitor', type: :feature do
       expect(page).to have_content('No Reviews Yet')
     end
   end
+
+  it 'deletes author and asociated books, leaving co-authors' do
+    author_1 = Author.create(name: "bob")
+    author_2 = Author.create(name:"andre")
+    book_1 = Book.create(title: "book 1", pages: 100, year_published: 1901, thumbnail: "picture url", authors: [author_1, author_2])
+    book_2 = Book.create(title: "book 2", pages: 100, year_published: 1901, thumbnail: "picture url", authors: [author_2])
+
+    visit author_path(author_1)
+
+    expect(page).to have_content('bob')
+    expect(page).to have_content('andre')
+    expect(page).to have_content('book 1')
+
+    click_button('Delete Author')
+
+    expect(current_path).to eq(books_path)
+
+    expect(page).to have_content('book 2')
+    expect(page).to have_content('andre')
+    expect(page).to_not have_content('book 1')
+    expect(page).to_not have_content('bob')
+  end
 end

--- a/spec/features/author/user_sees_author_show_page_spec.rb
+++ b/spec/features/author/user_sees_author_show_page_spec.rb
@@ -75,20 +75,22 @@ RSpec.describe 'as visitor', type: :feature do
     author_2 = Author.create(name:"andre")
     book_1 = Book.create(title: "book 1", pages: 100, year_published: 1901, thumbnail: "picture url", authors: [author_1, author_2])
     book_2 = Book.create(title: "book 2", pages: 100, year_published: 1901, thumbnail: "picture url", authors: [author_2])
+    book_3 = author_1.books.create(title: "book 3", pages: 100, year_published: 1901, thumbnail: "picture url")
 
     visit author_path(author_1)
 
     expect(page).to have_content('bob')
     expect(page).to have_content('andre')
     expect(page).to have_content('book 1')
-
-    click_button('Delete Author')
+    within ".book-#{book_3.id}" do
+      click_button('Delete Author')
+    end
 
     expect(current_path).to eq(books_path)
 
     expect(page).to have_content('book 2')
     expect(page).to have_content('andre')
-    expect(page).to_not have_content('book 1')
-    expect(page).to_not have_content('bob')
+    expect(page).to_not have_content('book 3')
+
   end
 end

--- a/spec/features/books/user_sees_book_show_page_spec.rb
+++ b/spec/features/books/user_sees_book_show_page_spec.rb
@@ -59,4 +59,24 @@ RSpec.describe 'As a visitor', type: :feature do
     end
   end
 
+  it 'had a delete button to remove the shown book' do
+    author = Author.create(name: "steve jobs")
+    user_1 = User.create(name: "bob")
+    book_1 = author.books.create(title: "Story about me", pages: 300, year_published: 300, thumbnail: "gibbergabber")
+    book_2 = author.books.create(title: "Huzzah", pages: 234, year_published: 553, thumbnail: "gibbergabber")
+    book_3 = author.books.create(title: "Hooray", pages: 4563, year_published: 343, thumbnail: "gibbergabber")
+    review_1 = book_1.reviews.create(title: "spectacular", description: "Really", rating: 5, user: user_1)
+    review_2 = book_1.reviews.create(title: "Amazing", description: "Really", rating: 4, user: user_1)
+    review_3 = book_1.reviews.create(title: "meh", description: "Really", rating: 4, user: user_1)
+    review_4 = book_1.reviews.create(title: "horrible", description: "Really", rating: 2, user: user_1)
+
+    visit(book_path(book_1))
+
+    within '#primary-info' do
+      expect(page).to have_content(book_1.title)
+      click_button('Delete Book')
+    end
+    
+    expect(current_path).to eq(books_path)
+  end
 end

--- a/spec/features/books/user_sees_book_show_page_spec.rb
+++ b/spec/features/books/user_sees_book_show_page_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'As a visitor', type: :feature do
     end
   end
 
-  it 'had a delete button to remove the shown book' do
+  it 'has a delete button to remove the shown book' do
     author = Author.create(name: "steve jobs")
     user_1 = User.create(name: "bob")
     book_1 = author.books.create(title: "Story about me", pages: 300, year_published: 300, thumbnail: "gibbergabber")
@@ -76,7 +76,10 @@ RSpec.describe 'As a visitor', type: :feature do
       expect(page).to have_content(book_1.title)
       click_button('Delete Book')
     end
-    
+
     expect(current_path).to eq(books_path)
+    expect(page).to have_content("Huzzah")
+    expect(page).to_not have_content("Story about me")
+
   end
 end

--- a/spec/features/users/user_show_page_spec.rb
+++ b/spec/features/users/user_show_page_spec.rb
@@ -48,5 +48,27 @@ RSpec.describe 'as a visitor', type: :feature do
         expect(page.all('#single-review')[1]).to have_content('better')
       end
     end
+
+    it 'shows a delete button to remove a review' do
+      user = User.create(name: 'Bobby')
+      author = Author.create(name: 'Author')
+      book_1 = author.books.create(title: 'book', pages: 200, year_published: 1012, )
+      book_2 = author.books.create(title: 'book 2', pages: 300, year_published: 2019, )
+      review_1 = book_1.reviews.create(title: 'good', description: 'aight', rating: 3, book_id: book_2.id, user_id: user.id)
+      review_2 = book_2.reviews.create(title: 'better', description: 'yay', rating: 4, book_id: book_1.id, user_id: user.id)
+
+      visit user_path(user.id)
+
+      within "#book-#{book_2.id}" do
+
+        click_button('Delete Review')
+
+        expect(page).to_not have_content('better')
+        expect(page).to_not have_content('yay')
+      end
+      expect(page).to have_content('good')
+      expect(current_path).to eq(user_path(user.id))
+
+    end
   end
 end

--- a/spec/features/users/user_show_page_spec.rb
+++ b/spec/features/users/user_show_page_spec.rb
@@ -59,15 +59,16 @@ RSpec.describe 'as a visitor', type: :feature do
 
       visit user_path(user.id)
 
+
       within "#book-#{book_2.id}" do
 
+        expect(page).to have_content('better')
+        expect(page).to have_content('yay')
         click_button('Delete Review')
-
-        expect(page).to_not have_content('better')
-        expect(page).to_not have_content('yay')
       end
-      expect(page).to have_content('good')
       expect(current_path).to eq(user_path(user.id))
+      expect(page).to have_content('good')
+      expect(page).to_not have_content('better')
 
     end
   end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe Review, type: :model do
   end
 
   describe 'instance methods' do
+    describe '.delete_review' do
+      it 'deletes a user review when the button is pressed' do
+        author = Author.create(name: "Rickey Bobby")
+        book_1 = Book.create(title: "Moby Dick", pages: 100, year_published: 1900, thumbnail: "gibberish", authors: [author])
+        user_1 = User.create(name: "bob")
+        review_1 = book_1.reviews.create(title: "Amazing", description: "Really", rating: 5, user: user_1)
+        review_2 = book_1.reviews.create(title: "Meh", description: "it's not great", rating: 2, user: user_1)
+
+        reviews = [review_1, review_2]
+
+        expect(review_2.delete_review).to_not eq(reviews)
+      end
+    end
   end
 
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Review, type: :model do
         review_1 = book_1.reviews.create(title: "Amazing", description: "Really", rating: 5, user: user_1)
         review_2 = book_1.reviews.create(title: "Meh", description: "it's not great", rating: 2, user: user_1)
 
-        reviews = [review_1, review_2]
+        review_2.delete_review(review_2.id)
 
-        expect(review_2.delete_review).to_not eq(reviews)
+        expect(Review.all).to_not include(review_2)
       end
     end
   end


### PR DESCRIPTION
Creates a delete feature for the author showpage.

User can successfully click on the delete button and it will remove the author and all associated books. It will also leave Authors who co-authored a book alone.

All associated tests passing.