### PR TITLE
Deleting user review #8

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,6 +15,11 @@ class ReviewsController < ApplicationController
     redirect_to book_path(params[:book_id])
   end
 
+  def destroy
+    Review.destroy(params[:id])
+    redirect_to user_path(params[:user])
+  end
+
   private
 
   def review_params

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -15,6 +15,7 @@ class Review < ApplicationRecord
   end
 
   def delete_review(id)
+    binding.pry
     Review.destroy(id)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -13,4 +13,8 @@ class Review < ApplicationRecord
       all
     end
   end
+
+  def delete_review(id)
+    Review.destroy(id)
+  end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,12 +8,13 @@
   <div class="book-image" id="author-book-img">
     <img src="<%= review.book.thumbnail %>" alt="<%= review.book.title %>-cover">
   </div>
-  <div class="book-info">
+  <div class="book-info" id="book-<%= review.book.id%>">
     <p id='review-title'><%= review.title %></p>
     <p><%= review.rating %> out of 5</p>
     <p><%= review.description %></p>
     <%= link_to "#{review.book.title}: ", book_path(review.book.id), class: 'navlink' %>
     <p>Created: <%= review.created_at %></p>
+    <%= button_to "Delete Review", review_path(review), method: :delete, params: {user: @user.id} %>
   </div>
 </section>
 <% end %>

--- a/spec/features/users/user_show_page_spec.rb
+++ b/spec/features/users/user_show_page_spec.rb
@@ -48,5 +48,27 @@ RSpec.describe 'as a visitor', type: :feature do
         expect(page.all('#single-review')[1]).to have_content('better')
       end
     end
+
+    it 'shows a delete button to remove a review' do
+      user = User.create(name: 'Bobby')
+      author = Author.create(name: 'Author')
+      book_1 = author.books.create(title: 'book', pages: 200, year_published: 1012, )
+      book_2 = author.books.create(title: 'book 2', pages: 300, year_published: 2019, )
+      review_1 = book_1.reviews.create(title: 'good', description: 'aight', rating: 3, book_id: book_2.id, user_id: user.id)
+      review_2 = book_2.reviews.create(title: 'better', description: 'yay', rating: 4, book_id: book_1.id, user_id: user.id)
+
+      visit user_path(user.id)
+
+      within "#book-#{book_2.id}" do
+
+        click_button('Delete Review')
+
+        expect(page).to_not have_content('better')
+        expect(page).to_not have_content('yay')
+      end
+      expect(page).to have_content('good')
+      expect(current_path).to eq(user_path(user.id))
+
+    end
   end
 end

--- a/spec/features/users/user_show_page_spec.rb
+++ b/spec/features/users/user_show_page_spec.rb
@@ -59,15 +59,16 @@ RSpec.describe 'as a visitor', type: :feature do
 
       visit user_path(user.id)
 
+
       within "#book-#{book_2.id}" do
 
+        expect(page).to have_content('better')
+        expect(page).to have_content('yay')
         click_button('Delete Review')
-
-        expect(page).to_not have_content('better')
-        expect(page).to_not have_content('yay')
       end
-      expect(page).to have_content('good')
       expect(current_path).to eq(user_path(user.id))
+      expect(page).to have_content('good')
+      expect(page).to_not have_content('better')
 
     end
   end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe Review, type: :model do
   end
 
   describe 'instance methods' do
+    describe '.delete_review' do
+      it 'deletes a user review when the button is pressed' do
+        author = Author.create(name: "Rickey Bobby")
+        book_1 = Book.create(title: "Moby Dick", pages: 100, year_published: 1900, thumbnail: "gibberish", authors: [author])
+        user_1 = User.create(name: "bob")
+        review_1 = book_1.reviews.create(title: "Amazing", description: "Really", rating: 5, user: user_1)
+        review_2 = book_1.reviews.create(title: "Meh", description: "it's not great", rating: 2, user: user_1)
+
+        reviews = [review_1, review_2]
+
+        expect(review_2.delete_review).to_not eq(reviews)
+      end
+    end
   end
 
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Review, type: :model do
         review_1 = book_1.reviews.create(title: "Amazing", description: "Really", rating: 5, user: user_1)
         review_2 = book_1.reviews.create(title: "Meh", description: "it's not great", rating: 2, user: user_1)
 
-        reviews = [review_1, review_2]
+        review_2.delete_review(review_2.id)
 
-        expect(review_2.delete_review).to_not eq(reviews)
+        expect(Review.all).to_not include(review_2)
       end
     end
   end


### PR DESCRIPTION
Adds a button to each review listed in the user show page.

When pressed the associated review will be deleted and the page will refresh displaying a the user's showpage without the selected review.